### PR TITLE
[fix]ページネーション/カレンダー

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -232,3 +232,19 @@
  // #table tr:hover td {
  //  background-color: #ACDEF7;
  // }
+
+ // ページネーション
+ .pagination {
+  justify-content: center;
+  border: none;
+ }
+
+ .pagination > li > a {
+  border: none;
+  color: #696969;
+ }
+
+ .pagination >li > a:hover {
+  color: red;
+  background-color: red;
+ }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,18 +23,18 @@
   padding: 0;
   box-sizing: border-box;
  }
- 
+
  // フォント
  header,
  main,
  footer {
   font-family: cursive, sans-serif;
  }
- 
+
  a:hover {
   text-decoration: none;
  }
- 
+
  // ヘッダー
  header {
   background: -moz-linear-gradient(top, #FFC778, #FFF);
@@ -181,7 +181,7 @@
  .favorite-btn {
   color: #F9E900;
  }
- 
+
  // ほめホメボタン
  .btn-circle {
   display: inline-block;
@@ -207,7 +207,7 @@
   -webkit-transform: translateY(-5px);
   transform: translateY(-5px);
  }
- 
+
  .btn-beat {
   color: #fff;
   font-size: 16px;
@@ -218,7 +218,7 @@
   display: inline-block;
   transition: .3s;
  }
- 
+
  .btn-beat:hover {
   animation: pulsation .7s alternate infinite;
  }
@@ -228,7 +228,7 @@
   50% { transform: scale(0.9); }
   100% { transform: scale(1.1); }
  }
- 
+
  // #table tr:hover td {
  //  background-color: #ACDEF7;
  // }

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,11 +1,3 @@
-<%# Link to the "First" page
-  - available local variables
-    url:           url to the first page
-    current_page:  a page object for the currently displayed page
-    total_pages:   total number of pages
-    per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
-<span class="first">
-  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote %>
-</span>
+<li class = "page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,8 +1,3 @@
-<%# Non-link tag that stands for skipped pages...
-  - available local variables
-    current_page:  a page object for the currently displayed page
-    total_pages:   total number of pages
-    per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
-<span class="page gap"><%= t('views.pagination.truncate').html_safe %></span>
+<li class = 'page-item disabled'>
+  <%= link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,11 +1,3 @@
-<%# Link to the "Last" page
-  - available local variables
-    url:           url to the last page
-    current_page:  a page object for the currently displayed page
-    total_pages:   total number of pages
-    per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
-<span class="last">
-  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote %>
-</span>
+<li class = "page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,11 +1,3 @@
-<%# Link to the "Next" page
-  - available local variables
-    url:           url to the next page
-    current_page:  a page object for the currently displayed page
-    total_pages:   total number of pages
-    per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
-<span class="next">
-  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote %>
-</span>
+<li class = "page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,12 +1,9 @@
-<%# Link showing page number
-  - available local variables
-    page:          a page object for "this" page
-    url:           url to this page
-    current_page:  a page object for the currently displayed page
-    total_pages:   total number of pages
-    per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
-<span class="page<%= ' current' if page.current? %>">
-  <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel} %>
-</span>
+<% if page.current? %>
+  <li class = "page-item active">
+    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link' %>
+  </li>
+<% else %>
+  <li class = "page-item">
+    <%= link_to page, url, remote: remote, rel: page.rel, class: 'page-link' %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,25 +1,17 @@
-<%# The container tag
-  - available local variables
-    current_page:  a page object for the currently displayed page
-    total_pages:   total number of pages
-    per_page:      number of items to fetch per page
-    remote:        data-remote
-    paginator:     the paginator that renders the pagination tags inside
--%>
-<%= paginator.render do -%>
-  <nav class="pagination" role="navigation" aria-label="pager">
-    <%= first_page_tag unless current_page.first? %>
-    <%= prev_page_tag unless current_page.first? %>
-    <% each_page do |page| -%>
-      <% if page.display_tag? -%>
-        <%= page_tag page %>
-      <% elsif !page.was_truncated? -%>
-        <%= gap_tag %>
-      <% end -%>
-    <% end -%>
-    <% unless current_page.out_of_range? %>
+<%= paginator.render do %>
+  <nav>
+    <ul class = "pagination">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| %>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end %>
+      <% end %>
       <%= next_page_tag unless current_page.last? %>
       <%= last_page_tag unless current_page.last? %>
-    <% end %>
+    </ul>
   </nav>
-<% end -%>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,11 +1,3 @@
-<%# Link to the "Previous" page
-  - available local variables
-    url:           url to the previous page
-    current_page:  a page object for the currently displayed page
-    total_pages:   total number of pages
-    per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
-<span class="prev">
-  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote %>
-</span>
+<li class ="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -10,7 +10,7 @@
             <li class = "nav-text pt-2 pr-5"><%= current_user.name %>さん、今日もえらい！</li>
             <li><%= link_to "Mypage", mypage_path(current_user), class: "nav-link px-4" %></li>
             <li><%= link_to "List", lists_path, class: "nav-link px-4 mx-5" %></li>
-            <li><%= link_to "Calendar", my_calendar_path(current_user), class: "nav-link px-4" %></li>
+            <li><%= link_to "Calendar", my_calendar_path(current_user), class: "nav-link px-4", data: {"turbolinks" => false} %></li>
             <li><%= link_to "Logout", destroy_user_session_path, method: :delete, class: "nav-link px-4 ml-5" %></li>
           <% elsif admin_signed_in? %>
             <li><%= link_to "Users", admin_users_path, class: "nav-link px-4" %></li>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -27,6 +27,13 @@ ja:
         restrict_dependent_destroy:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
+  views:
+    pagination:
+      first: <i class="fas fa-angle-double-left"></i>
+      last: <i class="fas fa-angle-double-right"></i>
+      previous: <i class="fas fa-angle-left"></i>
+      next: <i class="fas fa-angle-right"></i>
+      truncate: "..."
   date:
     abbr_day_names:
     - 日


### PR DESCRIPTION
ページネーション
- ページネーションのレイアウトを修正しました
- 日本語化しました

カレンダー
- ヘッダーのリンクからカレンダーが表示されなかったので以下を追加しました

修正前
```
<li><%= link_to "Calendar", my_calendar_path(current_user), class: "nav-link px-4" %></li>
```
修正後
```
<li><%= link_to "Calendar", my_calendar_path(current_user), class: "nav-link px-4", data: {"turbolinks" => false} %></li>
```
